### PR TITLE
Allow talking to `org.freedesktop.secrets`

### DIFF
--- a/org.gnome.gitlab.cheywood.Iotas.json
+++ b/org.gnome.gitlab.cheywood.Iotas.json
@@ -9,7 +9,8 @@
         "--share=ipc",
         "--socket=fallback-x11",
         "--share=network",
-        "--socket=wayland"
+        "--socket=wayland",
+        "--talk-name=org.freedesktop.secrets"
     ],
     "cleanup" : [
         "*.a",


### PR DESCRIPTION
https://gitlab.gnome.org/World/iotas#authentication-storage

> Iotas uses the Secret Service to store authentication details for Nextcloud. This is typically handled smoothly by GNOME Keyring but that may not be the case on mobile or other environments. KWallet is [reported](https://gitlab.gnome.org/World/iotas/-/issues/71) to not be working.

I think it should use [org.freedesktop.impl.portal.Secret](https://github.com/flatpak/xdg-desktop-portal/blob/main/data/org.freedesktop.impl.portal.Secret.xml) without any permission, but it didn't work for me. Does Iotas support it?